### PR TITLE
Add actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
           python setup.py install
       - name: Run Tests with Coverage
         run: |
-          coverage run -m unittest discover
+          coverage run -m unittest discover -s ./src/tests
           coverage report 
       - name: Run Demo
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: Test Craterstats
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+    
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source 
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Set up Python 
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install pip
+        run: |
+          python -m pip install --upgrade pip
+      - name: Install dependencies
+        run: |
+          python -m pip install -U -r requirements.txt
+          python -m pip install coverage
+      - name: Install Craterstats
+        run: |
+          python setup.py install
+      - name: Run Tests with Coverage
+        run: |
+          coverage run -m unittest discover
+          coverage report 
+      - name: Run Demo
+        run: |
+          craterstats -demo
+      - name: Upload Demo Plots
+        uses: actions/upload-artifact@v2
+        with:
+          path: demo/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ eggs/
 dist/
 sdist/
 demo/
+.coverage


### PR DESCRIPTION
Hey @ggmichael,

this PR adds a github workflow that runs the test suite, reports the coverage of the tests, and runs the demo command for the cli and then uploads the figures to a zip file using the upload-artifact action. 

Normally the owner of the repository needs to authorize/create workflows for a github repository. You may see a prompt to authorize the action/any and all actions to run either on the PR or in the actions tab for the project near the top of the page. 