### PR TITLE
fixes a dtype issue

### DIFF
--- a/src/craterstats/Craterpdf.py
+++ b/src/craterstats/Craterpdf.py
@@ -45,9 +45,10 @@ class Craterpdf:
             Ninc=(Ncum[0]-Ncum[1])*cc.area # no expected on area with phi(1 Ga)
             lam=Ninc
 
-        pdf0= gm.poisson(self.k, lam * 10 ** x)
-        self.pdf=pdf0/np.sum(pdf0*self.dt)
-        self.cdf=np.cumsum(self.pdf*self.dt)
+        pdf0 = gm.poisson(self.k, lam * 10 ** x)
+        pdf0 = pdf0.astype(float)
+        self.pdf = pdf0/np.sum(pdf0*self.dt)
+        self.cdf = np.cumsum(self.pdf*self.dt)
 
 
     def t(self,cum_fraction):


### PR DESCRIPTION
poisson seems to return object dtype instead of a float sometimes, I am not sure why that would ever happen but this seems to fix it, eventually scipy.stats should be used to replace code in gm module