### PR TITLE
addes demo example of poisson age text export

### DIFF
--- a/src/craterstats/config/demo_commands.txt
+++ b/src/craterstats/config/demo_commands.txt
@@ -59,6 +59,9 @@
 # output age data as text
 -f txt -title Age evaluation output as text -cs neukumivanov -p source=src/craterstats/sample/Pickering.scc,psym=o,binning=10/decade -p type=d-fit,range=[.2,.7],isochron=1 -p range=[2,5],colour=red,offset_age=[2,-3]
 
+# output age poisson data as text
+-f txt -title Age evaluation output as text -cs neukumivanov -p source=src/craterstats/sample/Pickering.scc,psym=fo -p type=poisson,range=[.2,.7],isochron=1
+
 # list supported chronology systems, equilibrium functions and epoch systems
 -lcs
 


### PR DESCRIPTION
locally this fails for me with the following stack trace, 

> Traceback (most recent call last):
  File "/home/andrew/anaconda3/envs/craterstats/bin/craterstats", line 33, in <module>
    sys.exit(load_entry_point('craterstats', 'console_scripts', 'craterstats')())
  File "/home/andrew/PycharmProjects/craterstats/src/craterstats/cli.py", line 313, in main
    cps.create_summary_table()
  File "/home/andrew/PycharmProjects/craterstats/src/craterstats/Craterplotset.py", line 391, in create_summary_table
    d = {k: getattr(cp, k) for k in
  File "/home/andrew/PycharmProjects/craterstats/src/craterstats/Craterplotset.py", line 391, in <dictcomp>
    d = {k: getattr(cp, k) for k in
AttributeError: 'Craterplot' object has no attribute 'bin_range'

Since there isn't a lot of documentation within the code I am not sure if it is okay to silently exclude the bin_range from consideration or not (you can just return None ie `getatter(object, attr, None)`), but if I can that is an easy fix