### PR TITLE
Add bootstrap CI and MLE fitting per Robbins et al. (2018)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -44,3 +44,21 @@ coordinate system for both layers)
 -----
 - Add MacOS binaries as beta
 - fix --functions_user config for pyinstaller versions
+
+3.7.0 (pending)
+---------------
+- Add ``BootstrapSFD`` class: KDE/EDF-based bootstrap confidence intervals for
+  crater size-frequency distributions, following Robbins et al. (2018),
+  *Meteoritics & Planetary Science* 53, 891–931.  Implements all four bootstrap
+  versions (V1.1 direct resample, V1.2 smoothed resample, V2 EDF sampling,
+  V3 hybrid — recommended).  CI can be expressed in differential, cumulative,
+  R-plot, or Hartmann presentation.
+- Add ``PowerLawMLE`` class: maximum likelihood estimation for crater SFD
+  power-law fitting (Robbins et al. 2018, §4–5).  Provides analytic MLE for
+  the unbounded Pareto distribution (Eqs. 9–11), numeric MLE for the truncated
+  Pareto (Eqs. 14–17), production-function regression through the origin
+  (Eqs. 18–23), and Pareto CI envelope plotting utilities.
+- Integrate bootstrap CI into ``Craterplot`` via new ``bootstrap_ci``,
+  ``bootstrap_version``, ``bootstrap_M``, ``bootstrap_psi``,
+  ``bootstrap_bw``, and ``bootstrap_show_2sigma`` settings.
+- Fix missing ``legend`` default in ``Craterplotset`` settings.

--- a/README.md
+++ b/README.md
@@ -9,11 +9,19 @@ This is a Python reimplementation and extension of the Craterstats-II software, 
 
 # Recent additions
 
-- Support for filename_CRATER.shp, filename_AREA.shp shapefile sets. These can be produced in, e.g. ArcPRO, 
+- **Bootstrap confidence intervals** (`BootstrapSFD` class): KDE/EDF-based bootstrap
+  CIs following [Robbins et al. (2018)](https://doi.org/10.1111/maps.12990).
+  Supports four bootstrap versions (V1.1, V1.2, V2, V3 hybrid — recommended) and
+  differential, cumulative, R-plot, and Hartmann presentations.
+  Integrated into `Craterplot` via the `bootstrap_ci` parameter.
+- **Maximum likelihood estimation** (`PowerLawMLE` class): direct MLE fitting of
+  the Pareto (power-law) slope to unbinned crater diameters, plus production-function
+  regression for age estimation, per Robbins et al. (2018) §4–5.
+- Support for filename_CRATER.shp, filename_AREA.shp shapefile sets. These can be produced in, e.g. ArcPRO,
 using three-point circle and polygon tools, as well as OpenCraterTools
 - Spatial randomness analysis (see Michael et al., 2012)
 
-Both features use spherical geometry for calculations 
+Both features use spherical geometry for calculations
 
 # Installation
 

--- a/src/craterstats/BootstrapSFD.py
+++ b/src/craterstats/BootstrapSFD.py
@@ -1,0 +1,355 @@
+#  Copyright (c) 2024, implemented per Robbins et al. (2018)
+#  Meteoritics & Planetary Science 53, 891-931. doi:10.1111/maps.12990
+#  Licensed under BSD 3-Clause License. See LICENSE.txt for details.
+
+import numpy as np
+from scipy.stats import norm
+
+
+class BootstrapSFD:
+    """
+    Kernel Density Estimate (KDE) based Empirical Distribution Function (EDF)
+    with bootstrap confidence intervals, following Robbins et al. (2018).
+
+    The EDF represents a Differential SFD where each crater is a Gaussian
+    with mean = measured diameter and sigma = bandwidth (default 0.1 * D_i).
+
+    Bootstrap versions:
+      '1.1' : Direct resampling with replacement (simple)
+      '1.2' : Direct resampling with smoothing (add Gaussian noise)
+      '2'   : Sampling the EDF (inverse CDF method)
+      '3'   : Hybrid — version 1.1 where data dense, version 2 where sparse
+               (Recommended by Robbins 2018)
+    """
+
+    def __init__(self, diameters, area=1.0, bandwidth_fraction=0.1, n_sigma=4, epsilon=1e-3):
+        """
+        :param diameters:          Array-like of crater diameters in km
+        :param area:               Survey area in km^2 (used to normalise to km^-2)
+        :param bandwidth_fraction: σ_i = bandwidth_fraction * D_i  (default 0.1)
+        :param n_sigma:            Truncation: evaluate kernel out to n_sigma * σ_i
+                                   beyond D_min / D_max  (default 4)
+        :param epsilon:            Diameter grid spacing in log10 space (default 1e-3)
+        """
+        diameters = np.asarray(diameters, dtype=float)
+        if diameters.ndim != 1 or len(diameters) == 0:
+            raise ValueError("diameters must be a non-empty 1-D array")
+
+        self.diameters = np.sort(diameters)          # ascending
+        self.N = len(self.diameters)
+        self.area = float(area)
+        self.bw_frac = float(bandwidth_fraction)
+        self.n_sigma = int(n_sigma)
+        self.epsilon = float(epsilon)
+
+        # per-crater bandwidths
+        self.sigma = self.bw_frac * self.diameters
+
+        # build the EDF on a dense diameter grid
+        self._build_edf()
+
+    # ------------------------------------------------------------------
+    # EDF construction
+    # ------------------------------------------------------------------
+
+    def _build_edf(self):
+        """Build the Differential EDF (DSFD_EDF) on a log-spaced diameter grid."""
+
+        D_min = self.diameters[0]
+        D_max = self.diameters[-1]
+        sigma_min = self.sigma[0]
+        sigma_max = self.sigma[-1]
+
+        # Grid extends n_sigma beyond observed range (Robbins 2018, p. 901)
+        d_lo = D_min - self.n_sigma * sigma_min
+        d_hi = D_max + self.n_sigma * sigma_max
+        d_lo = max(d_lo, 1e-6)   # prevent non-positive diameters
+
+        # Equation (5): log-spaced grid
+        v = int(np.floor(np.log(d_hi / d_lo) / self.epsilon)) + 1
+        i_vals = np.arange(v)
+        self.d_grid = d_lo * (d_hi / d_lo) ** (i_vals / max(v - 1, 1))
+
+        # DSFD_EDF = sum of normalised Gaussians (one per crater)
+        # Shape: (len(d_grid), N) → sum over craters
+        d2d = self.d_grid[:, np.newaxis]           # (v, 1)
+        mu = self.diameters[np.newaxis, :]          # (1, N)
+        sig = self.sigma[np.newaxis, :]             # (1, N)
+
+        # Gaussian PDF values (not truncated — we just evaluate broadly)
+        kernels = norm.pdf(d2d, loc=mu, scale=sig)  # (v, N)
+        self.dsfd_edf = kernels.sum(axis=1)         # (v,) raw sum
+
+        # Build CSFD_EDF by trapezoidal integration (Equation 2)
+        self.csfd_edf = self._dsfd_to_csfd(self.dsfd_edf, self.d_grid)
+
+        # Scaling factor ζ = N / CSFD_EDF(d_min)  (Equation 3)
+        # d_min for scaling is the grid point nearest to D_min - n_sigma*sigma_min
+        self.zeta = self.N / self.csfd_edf[0]
+
+        # Normalised (physically scaled) versions
+        self.dsfd_scaled = self.dsfd_edf * self.zeta / self.area
+        self.csfd_scaled = self.csfd_edf * self.zeta / self.area
+
+    @staticmethod
+    def _dsfd_to_csfd(dsfd, d_grid):
+        """
+        Integrate DSFD → CSFD using the trapezoidal rule, working right to left
+        (cumulative counts at diameter d = integral from d to d_max).
+        """
+        # ISFD_EDF(d_i) = (DSFD(d_i) + DSFD(d_{i+1})) / 2 * (d_{i+1} - d_i)
+        dd = np.diff(d_grid)                        # (v-1,)
+        isfd = 0.5 * (dsfd[:-1] + dsfd[1:]) * dd   # (v-1,)
+
+        # CSFD(d_i) = sum_{j=i}^{N-2} ISFD(j)  (cumulative from right)
+        csfd = np.zeros(len(d_grid))
+        csfd[:-1] = np.flip(np.cumsum(np.flip(isfd)))
+        return csfd
+
+    # ------------------------------------------------------------------
+    # Bootstrap CI computation
+    # ------------------------------------------------------------------
+
+    def bootstrap_ci(self, version='3', M=1000, psi=0.683, n_hybrid=0.75,
+                     rng=None):
+        """
+        Compute bootstrap confidence intervals per Robbins et al. (2018).
+
+        :param version:   Bootstrap version: '1.1', '1.2', '2', or '3' (default)
+        :param M:         Number of Monte Carlo iterations (default 1000)
+        :param psi:       Confidence level fraction (default 0.683 = 1σ)
+        :param n_hybrid:  Threshold factor n for hybrid version 3 (default 0.75)
+        :param rng:       numpy random Generator or seed for reproducibility
+        :return:          dict with keys:
+                            'd_grid'    : diameter grid (km)
+                            'dsfd_edf'  : original DSFD_EDF (normalised, per km^-2)
+                            'ci_lo'     : lower CI bound on DSFD_EDF (per km^-2)
+                            'ci_hi'     : upper CI bound on DSFD_EDF (per km^-2)
+                            'psi'       : confidence level used
+                            'version'   : bootstrap version used
+        """
+        if rng is None:
+            rng = np.random.default_rng()
+        elif isinstance(rng, (int, np.integer)):
+            rng = np.random.default_rng(int(rng))
+
+        M = int(M)
+        v = len(self.d_grid)
+
+        # Collect DSFD values from each bootstrap run: shape (M, v)
+        edf_runs = np.zeros((M, v))
+
+        if version == '1.1':
+            for i in range(M):
+                d_boot = self._resample_direct(rng)
+                edf_runs[i] = self._build_edf_from_diameters(d_boot)
+
+        elif version == '1.2':
+            for i in range(M):
+                d_boot = self._resample_smoothed(rng)
+                edf_runs[i] = self._build_edf_from_diameters(d_boot)
+
+        elif version == '2':
+            for i in range(M):
+                d_boot = self._resample_edf(rng)
+                edf_runs[i] = self._build_edf_from_diameters(d_boot)
+
+        elif version == '3':
+            for i in range(M):
+                d_boot = self._resample_hybrid(rng, n=n_hybrid)
+                edf_runs[i] = self._build_edf_from_diameters(d_boot)
+
+        else:
+            raise ValueError(f"Unknown bootstrap version '{version}'. "
+                             "Choose from '1.1', '1.2', '2', '3'.")
+
+        # Scale each run's EDF by the ORIGINAL ζ (step e in Robbins 2018)
+        # edf_runs are raw unscaled sums; multiply by zeta / area
+        edf_runs *= (self.zeta / self.area)
+
+        # --- CI construction (steps g–j in Robbins 2018) ---
+        # For each diameter, sort the M bootstrap values
+        edf_runs_sorted = np.sort(edf_runs, axis=0)     # (M, v)
+
+        # Original EDF (scaled)
+        dsfd_orig = self.dsfd_scaled                     # (v,)
+
+        # θ_i = position where bootstrap EDF matches the original (step g)
+        # Use searchsorted for efficiency
+        theta = np.array([
+            np.searchsorted(edf_runs_sorted[:, j], dsfd_orig[j])
+            for j in range(v)
+        ], dtype=float)
+
+        # Clip to valid range
+        theta = np.clip(theta, 0, M)
+
+        # Lower bound position: θ_i · (1−ψ)  (step h)
+        lo_pos = theta * (1.0 - psi)
+        # Upper bound position: (M − θ_i)·ψ + θ_i  (step i)
+        hi_pos = (M - theta) * psi + theta
+
+        # Clip index to [0, M-1] and extract values
+        lo_idx = np.clip(lo_pos.astype(int), 0, M - 1)
+        hi_idx = np.clip(hi_pos.astype(int), 0, M - 1)
+
+        ci_lo = edf_runs_sorted[lo_idx, np.arange(v)]
+        ci_hi = edf_runs_sorted[hi_idx, np.arange(v)]
+
+        return {
+            'd_grid': self.d_grid,
+            'dsfd_edf': dsfd_orig,
+            'csfd_edf': self.csfd_scaled,
+            'ci_lo': ci_lo,
+            'ci_hi': ci_hi,
+            'psi': psi,
+            'version': version,
+        }
+
+    # ------------------------------------------------------------------
+    # Bootstrap resampling strategies
+    # ------------------------------------------------------------------
+
+    def _resample_direct(self, rng):
+        """Version 1.1: sample N diameters with replacement."""
+        idx = rng.integers(0, self.N, size=self.N)
+        return np.sort(self.diameters[idx])
+
+    def _resample_smoothed(self, rng):
+        """Version 1.2: sample with replacement, then add Gaussian noise."""
+        idx = rng.integers(0, self.N, size=self.N)
+        d_sampled = self.diameters[idx]
+        sigma_sampled = self.bw_frac * d_sampled
+        noise = rng.normal(0, sigma_sampled)
+        d_new = np.abs(d_sampled + noise)   # keep positive
+        d_new = np.maximum(d_new, 1e-6)
+        return np.sort(d_new)
+
+    def _resample_edf(self, rng):
+        """Version 2: sample N diameters from the EDF via inverse CDF."""
+        # Normalise CSFD_EDF to [0, 1]
+        csfd_norm = self.csfd_edf / self.csfd_edf[0]   # max at d_lo = 1
+        # Draw N uniform samples
+        u = rng.uniform(0, 1, size=self.N)
+        # Inverse lookup: for each u, find diameter where csfd_norm == u
+        # csfd_norm is DECREASING (large at small d), so flip for searchsorted
+        csfd_flip = csfd_norm[::-1]
+        d_grid_flip = self.d_grid[::-1]
+        idx = np.searchsorted(csfd_flip, u)
+        idx = np.clip(idx, 0, len(self.d_grid) - 1)
+        return np.sort(d_grid_flip[idx])
+
+    def _resample_hybrid(self, rng, n=0.75):
+        """
+        Version 3: direct resampling where data are dense, EDF sampling where sparse.
+        Follows steps b.4-b.5 in Robbins 2018.
+        """
+        # First, get N diameters from the EDF (version 2 starting point)
+        d_edf = self._resample_edf(rng)
+        d_boot = np.empty(self.N)
+
+        d_sorted = self.diameters       # ascending
+        sigma_sorted = self.sigma       # ascending
+
+        D_min = d_sorted[0]
+        D_max = d_sorted[-1]
+
+        for k, d_i in enumerate(d_edf):
+            # Find closest original crater
+            j = np.argmin(np.abs(d_sorted - d_i))
+            D_closest = d_sorted[j]
+
+            if D_closest <= D_min:
+                # b.5.i: use D_min
+                d_boot[k] = D_min
+            elif D_closest >= D_max:
+                # b.5.ii: sparse at top — use EDF sample
+                d_boot[k] = d_i
+            else:
+                # b.5.iii: check density condition
+                j_prev = max(j - 1, 0)
+                j_next = min(j + 1, self.N - 1)
+                gap_lo = D_closest - d_sorted[j_prev]
+                gap_hi = d_sorted[j_next] - D_closest
+                thresh_lo = n * (sigma_sorted[j] + sigma_sorted[j_prev])
+                thresh_hi = n * (sigma_sorted[j_next] + sigma_sorted[j])
+                if gap_lo < thresh_lo and gap_hi < thresh_hi:
+                    # Dense region: use direct resampling (V1.1)
+                    d_boot[k] = D_closest
+                else:
+                    # Sparse region: use EDF sample (V2)
+                    d_boot[k] = d_i
+
+        return np.sort(d_boot)
+
+    # ------------------------------------------------------------------
+    # Helper: build raw DSFD from a set of diameters (same grid as self)
+    # ------------------------------------------------------------------
+
+    def _build_edf_from_diameters(self, diameters):
+        """
+        Build a raw (unscaled) DSFD on self.d_grid for a bootstrapped diameter set.
+
+        Returns DSFD values (sum of Gaussian kernels) on self.d_grid.
+        Uses the ORIGINAL ζ for scaling (applied externally).
+        """
+        sigma = self.bw_frac * diameters
+        d2d = self.d_grid[:, np.newaxis]        # (v, 1)
+        mu = diameters[np.newaxis, :]            # (1, N)
+        sig = sigma[np.newaxis, :]               # (1, N)
+        kernels = norm.pdf(d2d, loc=mu, scale=sig)  # (v, N)
+        return kernels.sum(axis=1)               # (v,) raw unscaled
+
+    # ------------------------------------------------------------------
+    # Conversion utilities: DSFD_EDF → other SFD formats
+    # ------------------------------------------------------------------
+
+    def ci_to_presentation(self, ci_result, presentation):
+        """
+        Convert bootstrap CI (computed on DSFD_EDF) to another SFD presentation.
+
+        The CI is RELATIVE to the DSFD_EDF, so the same relative fractional
+        uncertainty applies to all presentations.  Following Robbins 2018 §6:
+        if CI on DSFD_EDF at d_s is (+20%, -30%), then the CI on CSFD_EDF,
+        RSFD_EDF, ISFD_EDF at d_s is also (+20%, -30%).
+
+        :param ci_result:    dict returned by bootstrap_ci()
+        :param presentation: 'differential' | 'cumulative' | 'R-plot' | 'Hartmann'
+        :return: dict with keys 'd_grid', 'y', 'ci_lo', 'ci_hi'
+        """
+        dsfd = ci_result['dsfd_edf']
+        ci_lo = ci_result['ci_lo']
+        ci_hi = ci_result['ci_hi']
+        d = ci_result['d_grid']
+
+        # Relative CI factors
+        with np.errstate(divide='ignore', invalid='ignore'):
+            f_lo = np.where(dsfd > 0, ci_lo / dsfd, 0.0)
+            f_hi = np.where(dsfd > 0, ci_hi / dsfd, 0.0)
+
+        if presentation == 'differential':
+            y = dsfd
+            y_lo = ci_lo
+            y_hi = ci_hi
+
+        elif presentation == 'cumulative':
+            y = ci_result['csfd_edf']
+            y_lo = y * f_lo
+            y_hi = y * f_hi
+
+        elif presentation == 'R-plot':
+            y = dsfd * d ** 3
+            y_lo = y * f_lo
+            y_hi = y * f_hi
+
+        elif presentation == 'Hartmann':
+            # Hartmann: N_inc / bin_width * D * (√2 - 1)
+            # For continuous EDF: approximate as DSFD * D * (√2 - 1)
+            y = dsfd * d * (np.sqrt(2) - 1)
+            y_lo = y * f_lo
+            y_hi = y * f_hi
+
+        else:
+            raise ValueError(f"Unknown presentation '{presentation}'")
+
+        return {'d_grid': d, 'y': y, 'ci_lo': y_lo, 'ci_hi': y_hi}

--- a/src/craterstats/Craterplot.py
+++ b/src/craterstats/Craterplot.py
@@ -8,6 +8,7 @@ import re
 
 import craterstats as cst
 import craterstats.gm as gm
+from .BootstrapSFD import BootstrapSFD
 
 
 class Craterplot:
@@ -34,6 +35,12 @@ class Craterplot:
             'resurf_showall':0,
             'isochron':0,
             'offset_age':[0.,0.],
+            'bootstrap_ci':0,           # 0=off, 1=on
+            'bootstrap_version':'3',    # '1.1','1.2','2','3'
+            'bootstrap_M':1000,         # Monte Carlo iterations
+            'bootstrap_psi':0.683,      # confidence level (0.683=1σ, 0.954=2σ)
+            'bootstrap_bw':0.1,         # bandwidth fraction (σ_i = bw * D_i)
+            'bootstrap_show_2sigma':0,  # also draw 2σ envelope
             },*args,kwargs)
 
         self.range = self.cratercount.decode_range(self.range,self.binning,self.snap)
@@ -55,8 +62,12 @@ class Craterplot:
                      'resurf_showall',
                      'isochron',
                      'psym',
+                     'bootstrap_ci',
+                     'bootstrap_show_2sigma',
                      ):
                 v = int(v)
+            if k == 'bootstrap_M': v = int(v)
+            if k in ('bootstrap_psi', 'bootstrap_bw'): v = float(v)
             setattr(self, k, v)
         if not self.cratercount and self.source:
             self.cratercount = cst.Cratercount(self.source)
@@ -161,6 +172,10 @@ class Craterplot:
         """
         if not self.cratercount or self.hide: return
 
+        # Resolve integer colour index to actual matplotlib color string
+        if isinstance(self.colour, int):
+            self.colour = cps.palette[self.colour]
+
         if cps.presentation=='sequence':
             self.overplot_sequence_element(cps)
             return
@@ -177,6 +192,9 @@ class Craterplot:
 
         if self.error_bars:
             cps.ax.errorbar(np.log10(p['d']),p['y'],yerr=p['err'],fmt='none',linewidth=.5*cps.sz_ratio,ecolor=cps.grey[0],zorder=-1)
+
+        if self.bootstrap_ci and self.type == 'data' and not self.cratercount.prebinned:
+            self._overplot_bootstrap_ci(cps)
 
         if self.type in ['c-fit','d-fit','poisson','b-poisson']:
             self.calculate_age(cps)
@@ -221,6 +239,109 @@ class Craterplot:
                     **cps.marker_def[self.psym],ls='',color=self.colour)
 
 
+
+    def _overplot_bootstrap_ci(self, cps):
+        """
+        Compute and draw Robbins (2018) bootstrap confidence interval envelope.
+        Called from overplot() when bootstrap_ci=1 and data is unbinned.
+        """
+        cc = self.cratercount
+        if not hasattr(cc, 'diam') or cc.diam is None or len(cc.diam) == 0:
+            return
+
+        diameters = np.array(cc.diam)
+
+        # Filter to the plot diameter range if set
+        r = self.range
+        if r[0] > 0:
+            diameters = diameters[diameters >= r[0]]
+        if r[1] < np.inf:
+            diameters = diameters[diameters <= r[1]]
+        if len(diameters) < 2:
+            return
+
+        sfd = BootstrapSFD(diameters, area=cc.area, bandwidth_fraction=self.bootstrap_bw)
+
+        # Compute 1σ CI
+        ci = sfd.bootstrap_ci(version=self.bootstrap_version,
+                               M=self.bootstrap_M,
+                               psi=self.bootstrap_psi)
+
+        pres = cps.presentation
+        converted = sfd.ci_to_presentation(ci, pres)
+
+        d_grid = converted['d_grid']
+        y = converted['y']
+        ci_lo = converted['ci_lo']
+        ci_hi = converted['ci_hi']
+
+        # Only plot where values are positive (log-log axes)
+        mask = (y > 0) & (ci_lo > 0) & (ci_hi > 0)
+        if not np.any(mask):
+            return
+
+        alpha_fill = 0.25
+        # Resolve integer colour index to actual matplotlib color string
+        c = cps.palette[self.colour] if isinstance(self.colour, int) else self.colour
+
+        # x-axis: linear scale in log10(diameter); y-axis: log scale in actual density
+        cps.ax.fill_between(
+            np.log10(d_grid[mask]),
+            ci_lo[mask],
+            ci_hi[mask],
+            color=c,
+            alpha=alpha_fill,
+            linewidth=0,
+            zorder=-2,
+        )
+        # Draw the EDF curve itself (thin dashed line)
+        mask_y = y > 0
+        cps.ax.plot(
+            np.log10(d_grid[mask_y]),
+            y[mask_y],
+            color=c,
+            lw=0.5 * cps.sz_ratio,
+            ls='--',
+            zorder=-1,
+        )
+
+        # Optionally draw 2σ envelope
+        if self.bootstrap_show_2sigma:
+            ci2 = sfd.bootstrap_ci(version=self.bootstrap_version,
+                                    M=self.bootstrap_M,
+                                    psi=0.954)
+            converted2 = sfd.ci_to_presentation(ci2, pres)
+            ci_lo2 = converted2['ci_lo']
+            ci_hi2 = converted2['ci_hi']
+            mask2 = (y > 0) & (ci_lo2 > 0) & (ci_hi2 > 0)
+            if np.any(mask2):
+                cps.ax.fill_between(
+                    np.log10(d_grid[mask2]),
+                    ci_lo2[mask2],
+                    ci_hi2[mask2],
+                    color=c,
+                    alpha=alpha_fill * 0.5,
+                    linewidth=0,
+                    zorder=-3,
+                )
+
+        # Rug plot: small tick marks at original crater diameters (Robbins 2018, rec. #9)
+        rug_y = cps.ax.get_ylim()[0]
+        rug_diameters = np.array(cc.diam)
+        if r[0] > 0:
+            rug_diameters = rug_diameters[rug_diameters >= r[0]]
+        if r[1] < np.inf:
+            rug_diameters = rug_diameters[rug_diameters <= r[1]]
+        cps.ax.plot(
+            np.log10(rug_diameters),
+            np.full(len(rug_diameters), rug_y),
+            '|',
+            color=c,
+            markersize=3 * cps.sz_ratio,
+            markeredgewidth=0.5 * cps.sz_ratio,
+            zorder=2,
+            clip_on=True,
+        )
 
     def make_legend_label(self,cps):
         legend_label = []

--- a/src/craterstats/Craterplotset.py
+++ b/src/craterstats/Craterplotset.py
@@ -59,6 +59,7 @@ class Craterplotset:
             'invert':0,
             'text_halo':1,
             'bins':False,
+            'legend':'fnacr',
             },*args,kwargs)
 
         self.sz_ratio= self.pt_size / 9.

--- a/src/craterstats/PowerLawMLE.py
+++ b/src/craterstats/PowerLawMLE.py
@@ -1,0 +1,402 @@
+#  Copyright (c) 2024, implemented per Robbins et al. (2018)
+#  Meteoritics & Planetary Science 53, 891-931. doi:10.1111/maps.12990
+#  Licensed under BSD 3-Clause License. See LICENSE.txt for details.
+
+import warnings
+
+import numpy as np
+import scipy.optimize as sc
+from scipy.special import erfinv
+from scipy.stats import t as t_dist
+
+
+class PowerLawMLE:
+    """
+    Maximum likelihood estimation (MLE) for crater SFD power-law fitting.
+    Implements Robbins et al. (2018), Sections 4–5.
+
+    Reference
+    ---------
+    Robbins et al. (2018), Meteoritics & Planetary Science 53, 891-931.
+    doi:10.1111/maps.12990
+
+    Conventions
+    -----------
+    α > 0 : Pareto exponent (PDF decreases with increasing D).
+    ǎ = -(α+1) : differential SFD slope  [Robbins 2018, Eq. 8]
+    So α=3 → ǎ=-4, consistent with the canonical lunar SFD.
+
+    Methods
+    -------
+    fit_pareto            Analytic MLE for unbounded power-law  (Eqs. 9-11)
+    fit_truncated_pareto  Numeric MLE with upper cutoff D_max   (Eqs. 14-17)
+    fit_pf                Production-function regression         (Eqs. 18-23)
+    power_law_envelope    Compute Pareto shape curves for plotting
+    """
+
+    # ------------------------------------------------------------------
+    # Pareto (unbounded) MLE — Robbins 2018 Eqs. 9-11
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def fit_pareto(diameters, d_min=None, ci_levels=(0.683, 0.954)):
+        """
+        Fit unbounded Pareto distribution to crater diameters via analytic MLE.
+
+        Estimator (Eq. 9):   α̂ = N / Σ ln(D_i / D_min)
+        Uncertainty (Eq. 10): σ_α = α̂ / √N
+        CI envelope (Eq. 11): λ ≅ √2 · σ_α · erf⁻¹(ψ)
+
+        Parameters
+        ----------
+        diameters : array-like
+            Crater diameters in km.  All D ≥ d_min are used.
+        d_min : float, optional
+            Minimum diameter for fit.  Defaults to min(diameters).
+        ci_levels : tuple of float
+            Confidence levels for the CI envelope (e.g. 0.683 = 1σ, 0.954 = 2σ).
+
+        Returns
+        -------
+        dict with keys:
+            'alpha'       – MLE estimate α̂
+            'sigma_alpha' – 1-σ uncertainty  σ_α = α̂/√N          (Eq. 10)
+            'lambda'      – list of λ values (one per ci_level)    (Eq. 11)
+            'ci_levels'   – list of CI levels matching 'lambda'
+            'dsfd_slope'  – differential SFD slope  ǎ = -(α̂+1)    (Eq. 8)
+            'N'           – number of craters used
+            'd_min'       – d_min used
+            'model'       – 'pareto'
+        """
+        diameters = np.asarray(diameters, dtype=float)
+        if d_min is None:
+            d_min = float(diameters.min())
+        else:
+            d_min = float(d_min)
+
+        d_fit = diameters[diameters >= d_min]
+        N = len(d_fit)
+        if N < 2:
+            raise ValueError(
+                f"Only {N} craters at D ≥ {d_min:.4f} km; need at least 2.")
+
+        # Eq. 9: analytic MLE estimator
+        alpha_hat = N / np.sum(np.log(d_fit / d_min))
+
+        # Eq. 10: σ_α = α̂ / √N
+        sigma_alpha = alpha_hat / np.sqrt(N)
+
+        # Eq. 11: λ = √2 · σ_α · erf⁻¹(ψ)
+        lambdas = [float(np.sqrt(2.0) * sigma_alpha * erfinv(float(psi)))
+                   for psi in ci_levels]
+
+        return {
+            'alpha':       float(alpha_hat),
+            'sigma_alpha': float(sigma_alpha),
+            'lambda':      lambdas,
+            'ci_levels':   list(ci_levels),
+            'dsfd_slope':  float(-(alpha_hat + 1.0)),   # Eq. 8
+            'N':           N,
+            'd_min':       d_min,
+            'model':       'pareto',
+        }
+
+    # ------------------------------------------------------------------
+    # Truncated Pareto MLE — Robbins 2018 Eqs. 14-17
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def fit_truncated_pareto(diameters, d_min=None, d_max=None,
+                             ci_levels=(0.683, 0.954)):
+        """
+        Fit truncated Pareto distribution (D_min ≤ D ≤ D_max) via numeric MLE.
+
+        Score equation (Eq. 14), solved with Brent's method:
+            S(α) = N/α + N·r^α·ln(r)/(1−r^α) − Σ ln(D_i/D_min) = 0
+            where r = D_min/D_max < 1
+
+        Asymptotic variance from Fisher information (Eqs. 15-17):
+            I(α) = N/α² − N·(ln r)²·r^α/(1−r^α)²
+            Avar(α̂) = 1/I(α̂)
+
+        Parameters
+        ----------
+        diameters : array-like
+            Crater diameters in km.
+        d_min : float, optional
+            Lower truncation point.  Defaults to min(diameters).
+        d_max : float, optional
+            Upper truncation point.  Defaults to max(diameters).
+        ci_levels : tuple of float
+            Confidence levels for CI envelope.
+
+        Returns
+        -------
+        dict — same structure as fit_pareto(), with additional key 'd_max'.
+        """
+        diameters = np.asarray(diameters, dtype=float)
+        if d_min is None:
+            d_min = float(diameters.min())
+        if d_max is None:
+            d_max = float(diameters.max())
+        d_min, d_max = float(d_min), float(d_max)
+
+        if d_max <= d_min:
+            raise ValueError(
+                f"d_max ({d_max:.4f}) must be > d_min ({d_min:.4f})")
+
+        d_fit = diameters[(diameters >= d_min) & (diameters <= d_max)]
+        N = len(d_fit)
+        if N < 2:
+            raise ValueError(
+                f"Only {N} craters in [{d_min:.4f}, {d_max:.4f}] km; need ≥ 2.")
+
+        r = d_min / d_max        # < 1
+        ln_r = np.log(r)         # < 0
+        sum_lnD = np.sum(np.log(d_fit / d_min))    # > 0
+
+        # Score function S(α) — Eq. 14
+        # Derivation: ∂ℓ/∂α = N/α + N·r^α·ln(r)/(1−r^α) − Σln(D_i/D_min) = 0
+        # S → +∞ as α→0⁺;  S → −Σln(D_i/D_min) < 0 as α→+∞
+        def score(alpha):
+            r_a = r ** alpha
+            denom = 1.0 - r_a
+            if denom < 1e-300:
+                return -np.inf
+            return N / alpha + N * r_a * ln_r / denom - sum_lnD
+
+        # Bracket: lo near 0, hi = 2× unbounded estimate (always negative)
+        lo = 1e-8
+        hi = 2.0 * N / sum_lnD
+        for _ in range(80):
+            if score(hi) < 0.0:
+                break
+            hi *= 2.0
+        else:
+            raise RuntimeError(
+                "Could not bracket root of truncated Pareto score function. "
+                "Check d_min / d_max values.")
+
+        alpha_hat = sc.brentq(score, lo, hi, xtol=1e-12, rtol=1e-12)
+
+        # Fisher information I(α) = N/α² − N·(ln r)²·r^α/(1−r^α)²
+        # (negative expected second derivative of log-likelihood)
+        r_a   = r ** alpha_hat
+        denom = 1.0 - r_a
+        fisher_info = (N / alpha_hat ** 2
+                       - N * ln_r ** 2 * r_a / denom ** 2)
+
+        if fisher_info <= 0.0:
+            warnings.warn(
+                "Fisher information is non-positive; uncertainty estimate may be "
+                "unreliable.  Consider widening the diameter range or using the "
+                "unbounded Pareto fit.")
+            fisher_info = N / alpha_hat ** 2 * 1e-6   # safe fallback
+
+        sigma_alpha = float(np.sqrt(1.0 / fisher_info))
+
+        # Eq. 11 (same form as unbounded case)
+        lambdas = [float(np.sqrt(2.0) * sigma_alpha * erfinv(float(psi)))
+                   for psi in ci_levels]
+
+        return {
+            'alpha':       float(alpha_hat),
+            'sigma_alpha': float(sigma_alpha),
+            'lambda':      lambdas,
+            'ci_levels':   list(ci_levels),
+            'dsfd_slope':  float(-(alpha_hat + 1.0)),
+            'N':           N,
+            'd_min':       d_min,
+            'd_max':       d_max,
+            'model':       'truncated_pareto',
+        }
+
+    # ------------------------------------------------------------------
+    # Production-function regression — Robbins 2018 Eqs. 18-23
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def fit_pf(sfd_edf, pf, d_range=None, presentation='cumulative', psi=0.683):
+        """
+        Fit a production function to the EDF by regression through the origin.
+        (Robbins 2018, Eqs. 18–23)
+
+        Model:  SFD_EDF(D_i) = β₁ · PF(D_i, a0=0) + ε_i
+
+        Estimator (Eq. 20):
+            β̂₁ = Σ [SFD_EDF(D_i) · PF(D_i)] / Σ [PF(D_i)²]
+
+        The EDF is interpolated onto each measured crater diameter D_i.
+        PF is evaluated at a0 = 0 (shape only; amplitude encoded in β̂₁).
+        Converting: a0_fit = log₁₀(β̂₁).
+
+        Parameters
+        ----------
+        sfd_edf : BootstrapSFD
+            Instance with attributes .diameters, .d_grid, .csfd_scaled,
+            .dsfd_scaled, .area.
+        pf : Productionfn
+            craterstats production-function instance (.C and .F methods).
+        d_range : [float, float], optional
+            Diameter range [d_lo, d_hi] to use in fit.
+            Defaults to full range of sfd_edf.diameters.
+        presentation : str
+            'cumulative' (default) or 'differential'.
+        psi : float
+            Confidence level for the t-interval on β̂₁ (default 0.683 ≈ 1σ).
+
+        Returns
+        -------
+        dict with keys:
+            'beta1'        – best-fit scaling factor β̂₁
+            'beta1_lo'     – lower CI on β̂₁            (Eq. 23)
+            'beta1_hi'     – upper CI on β̂₁
+            'sigma_beta1'  – standard error on β̂₁      (Eq. 22)
+            'a0'           – log₁₀(β̂₁), i.e. craterstats-equivalent a0
+            'a0_lo'        – lower CI on a0
+            'a0_hi'        – upper CI on a0
+            'mse'          – mean squared error of the fit
+            'N'            – number of data points used
+            'presentation' – SFD presentation used
+        """
+        d_all = sfd_edf.diameters   # ascending km
+
+        if d_range is not None:
+            mask = (d_all >= d_range[0]) & (d_all <= d_range[1])
+        else:
+            mask = np.ones(len(d_all), dtype=bool)
+
+        d_pts = d_all[mask]
+        N = int(mask.sum())
+        if N < 2:
+            raise ValueError(f"Only {N} craters in fit range; need at least 2.")
+
+        # Interpolate EDF at each crater diameter
+        if presentation == 'cumulative':
+            edf_vals = np.interp(d_pts, sfd_edf.d_grid, sfd_edf.csfd_scaled)
+            pf_vals  = pf.C(d_pts, 0.0)
+        elif presentation == 'differential':
+            edf_vals = np.interp(d_pts, sfd_edf.d_grid, sfd_edf.dsfd_scaled)
+            pf_vals  = pf.F(d_pts, 0.0)
+        else:
+            raise ValueError(
+                f"presentation must be 'cumulative' or 'differential', "
+                f"got '{presentation}'")
+
+        # Eq. 20: β̂₁ = Σ(y_i · x_i) / Σ(x_i²)
+        sum_xy = float(np.dot(edf_vals, pf_vals))
+        sum_x2 = float(np.dot(pf_vals, pf_vals))
+        if sum_x2 == 0.0:
+            raise ValueError(
+                "Production function evaluates to zero at all data points.")
+
+        beta1 = sum_xy / sum_x2
+
+        # Eq. 21: MSE = Σ(y_i − β̂₁·x_i)² / (N−1)
+        residuals = edf_vals - beta1 * pf_vals
+        mse = float(np.dot(residuals, residuals)) / max(N - 1, 1)
+
+        # Eq. 22: Var(β̂₁) = MSE / Σ(x_i²)
+        sigma_beta1 = float(np.sqrt(max(mse / sum_x2, 0.0)))
+
+        # Eq. 23: t-statistic CI  — P(|T| ≤ t_crit) = psi
+        t_crit = float(t_dist.ppf((1.0 + psi) / 2.0, df=max(N - 1, 1)))
+        margin    = t_crit * sigma_beta1
+        beta1_lo  = max(float(beta1) - margin, 1e-300)
+        beta1_hi  = float(beta1) + margin
+
+        with np.errstate(divide='ignore'):
+            a0    = float(np.log10(max(float(beta1), 1e-300)))
+            a0_lo = float(np.log10(beta1_lo))
+            a0_hi = float(np.log10(beta1_hi))
+
+        return {
+            'beta1':        float(beta1),
+            'beta1_lo':     float(beta1_lo),
+            'beta1_hi':     float(beta1_hi),
+            'sigma_beta1':  float(sigma_beta1),
+            'a0':           a0,
+            'a0_lo':        a0_lo,
+            'a0_hi':        a0_hi,
+            'mse':          float(mse),
+            'N':            N,
+            'presentation': presentation,
+        }
+
+    # ------------------------------------------------------------------
+    # Plotting utility — Pareto shape envelopes
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def power_law_envelope(d_grid, alpha_hat, d_min, lambdas, ci_levels,
+                           presentation='differential'):
+        """
+        Compute Pareto power-law SFD shapes for the MLE best fit and CI envelopes.
+
+        All shapes are **normalised to 1.0 at d_min**.  To obtain absolute
+        densities, multiply by the EDF value at d_min:
+            edf_anchor = np.interp(d_min, sfd.d_grid, sfd.dsfd_scaled)
+
+        The CI envelope reflects the uncertainty in slope α:
+            y_hi → shallower slope (α̂ − λ) → higher values at large D
+            y_lo → steeper slope  (α̂ + λ) → lower  values at large D
+
+        Parameters
+        ----------
+        d_grid       : array-like – diameter grid (km); d < d_min are excluded
+        alpha_hat    : float      – MLE Pareto exponent α̂
+        d_min        : float      – reference / normalisation diameter
+        lambdas      : list       – λ values from fit_pareto / fit_truncated_pareto
+        ci_levels    : list       – confidence levels matching lambdas
+        presentation : str        – 'differential', 'cumulative', or 'R-plot'
+
+        Returns
+        -------
+        dict with keys:
+            'd_grid'    – diameters (km), d ≥ d_min
+            'y_fit'     – best-fit shape (= 1.0 at d_min)
+            'envelopes' – list of dicts, one per CI level:
+                          {'psi', 'lambda', 'y_lo', 'y_hi'}
+        """
+        d_grid = np.asarray(d_grid, dtype=float)
+        mask = d_grid >= d_min
+        d    = d_grid[mask]
+        x    = d / d_min    # ≥ 1
+
+        if presentation == 'differential':
+            # DSFD ∝ D^{-(α+1)}
+            def shape(alpha):
+                return x ** (-(alpha + 1.0))
+
+        elif presentation == 'cumulative':
+            # CSFD ∝ D^{-α}
+            def shape(alpha):
+                return x ** (-alpha)
+
+        elif presentation == 'R-plot':
+            # R = DSFD · D³ ∝ D^{2−α}
+            def shape(alpha):
+                return x ** (2.0 - alpha)
+
+        else:
+            raise ValueError(f"Unknown presentation '{presentation}'.")
+
+        y_fit = shape(alpha_hat)
+
+        envelopes = []
+        for lam, psi in zip(lambdas, ci_levels):
+            envelopes.append({
+                'psi':    float(psi),
+                'lambda': float(lam),
+                'y_lo':   shape(alpha_hat + lam),   # steeper → lower at large D
+                'y_hi':   shape(alpha_hat - lam),   # shallower → higher at large D
+            })
+
+        return {
+            'd_grid':       d,
+            'y_fit':        y_fit,
+            'envelopes':    envelopes,
+            'alpha':        float(alpha_hat),
+            'd_min':        float(d_min),
+            'presentation': presentation,
+        }

--- a/src/craterstats/__init__.py
+++ b/src/craterstats/__init__.py
@@ -12,6 +12,8 @@ from .Craterpdf import Craterpdf
 from .Epochs import Epochs
 from .Spatialcount import Spatialcount
 from .Randomnessanalysis import Randomnessanalysis
+from .BootstrapSFD import BootstrapSFD
+from .PowerLawMLE import PowerLawMLE
 
 from .miscellaneous import *
 from .constants import *


### PR DESCRIPTION
## Summary

This PR implements the statistical methods described in:

> Robbins et al. (2018), *Meteoritics & Planetary Science* **53**, 891–931.
> doi:[10.1111/maps.12990](https://doi.org/10.1111/maps.12990)

### New class: `BootstrapSFD`

KDE/EDF-based bootstrap confidence intervals for crater SFDs.

- Each crater is modelled as a Gaussian kernel with σ_i = 0.1·D_i, summed to a smooth differential EDF.
- Bootstrap CI computed over M iterations with four resample strategies:
  - **V1.1** direct resample with replacement
  - **V1.2** direct resample + Gaussian smoothing
  - **V2** EDF inverse-CDF sampling
  - **V3** hybrid V1.1/V2 *(recommended by Robbins 2018)*
- CI follows the asymmetric construction in steps g–j of Robbins (2018): percentile positions relative to the original EDF value in the sorted bootstrap ensemble.
- `ci_to_presentation()` converts the CI to differential, cumulative, R-plot, or Hartmann format.

**Basic usage:**
```python
from craterstats.BootstrapSFD import BootstrapSFD
sfd = BootstrapSFD(diameters, area=area)
ci  = sfd.bootstrap_ci(version='3', M=1000, psi=0.683)
```

### New class: `PowerLawMLE`

Maximum likelihood estimation for crater SFD power-law fitting (Robbins 2018, §4–5).

- `fit_pareto()` — analytic MLE: α̂ = N/Σln(D_i/D_min), uncertainty σ_α = α̂/√N, CI envelope λ (Eqs. 9–11)
- `fit_truncated_pareto()` — numeric MLE via Brent root-finding of the score equation, Fisher information uncertainty (Eqs. 14–17)
- `fit_pf()` — production-function regression through the origin β̂₁ = Σ(EDF·PF)/Σ(PF²); returns a0 = log₁₀(β̂₁) with t-statistic CI for direct use in age estimation (Eqs. 18–23)
- `power_law_envelope()` — Pareto shape curves for plotting fit and CI fan

**Basic usage:**
```python
from craterstats.PowerLawMLE import PowerLawMLE
res = PowerLawMLE.fit_pareto(diameters, d_min=D_min)
# res['alpha'], res['sigma_alpha'], res['dsfd_slope'] (= -(α+1)), res['lambda']

res_pf = PowerLawMLE.fit_pf(sfd_edf, pf, presentation='cumulative')
age    = cf.t(a0=res_pf['a0'])
```

### `Craterplot` integration

Bootstrap CIs can be added to any data overplot with new settings:

```python
cpl = cst.Craterplot(
    cratercount=cc, type='data',
    bootstrap_ci=1,
    bootstrap_version='3',    # 'V3' hybrid (recommended)
    bootstrap_M=1000,
    bootstrap_psi=0.683,      # 1σ
    bootstrap_show_2sigma=1,  # also draw 2σ envelope
)
```

### Bug fixes

- `Craterplotset`: added missing `'legend': 'fnacr'` default to settings dict (caused `AttributeError` if `legend` was not set explicitly).
- `Craterplot.overplot()`: resolve integer `colour` index to palette hex string before drawing (avoids `TypeError` in newer matplotlib versions).

## Test plan

- [ ] `BootstrapSFD` all four versions run without error on synthetic Pareto data and on Pickering sample data
- [ ] `ci_to_presentation()` runs for differential, cumulative, R-plot, Hartmann
- [ ] `PowerLawMLE.fit_pareto()` recovers known α within ≈1σ for N=100 synthetic craters
- [ ] `PowerLawMLE.fit_truncated_pareto()` gives α̂ ≤ unbounded estimate (correct truncation direction)
- [ ] `PowerLawMLE.fit_pf()` on Pickering + Neukum 1983 gives age ≈ 0.23 Ga (consistent with published estimates)
- [ ] `Craterplot(bootstrap_ci=1)` renders without error with `Craterplotset`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)